### PR TITLE
[feat] Remove dependency on pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
 module github.com/kinbiko/bugsnag
 
-go 1.12
+go 1.13
 
-require (
-	github.com/kinbiko/jsonassert v1.0.1
-	github.com/pkg/errors v0.8.1
-)
+require github.com/kinbiko/jsonassert v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 github.com/kinbiko/jsonassert v1.0.1 h1:8gdLmUaPWuxk2TzQSofKRqatFH6zwTF6AsUH4bugJYY=
 github.com/kinbiko/jsonassert v1.0.1/go.mod h1:QRwBwiAsrcJpjw+L+Q4WS8psLxuUY+HylVZS/4j74TM=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/kinbiko/jsonassert"
-	pkgerrors "github.com/pkg/errors"
 )
 
 func TestApp(t *testing.T) {
@@ -69,7 +68,7 @@ func TestMakeExceptions(t *testing.T) {
 	ctx = WithMetadatum(ctx, "tab", "one", "1")
 
 	err = errors.New("1st error (errors.New)")
-	err = pkgerrors.Wrap(err, "2nd error (github.com/pkg/errors.Wrap)")
+	err = fmt.Errorf("2nd error (github.com/pkg/errors.Wrap): %w", err)
 	err = n.Wrap(WithMetadatum(ctx, "tab", "two", "2"), err, "3rd error (%s.(*Notifier).Wrap)", "bugsnag")
 	err = fmt.Errorf("4th error (fmt.Errorf('percent-w')): %w", err)
 
@@ -89,7 +88,7 @@ func TestMakeExceptions(t *testing.T) {
 				{"file":"<<PRESENCE>>","inProject":false,"lineNumber":"<<PRESENCE>>","method":"<<PRESENCE>>"}
 			]
 		}, {
-			"errorClass": "*errors.withStack",
+			"errorClass": "*fmt.wrapError",
 			"message": "2nd error (github.com/pkg/errors.Wrap): 1st error (errors.New)",
 			"stacktrace": null
 		}, {


### PR DESCRIPTION
This dependency was really only used in tests anyway, but there's really
no reason to put it in tests either.

Also bumps the go version in go.mod as we're using wrapped errors.