### PR TITLE
[feat] Implement Close()

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -211,7 +211,6 @@ func TestReportSerialization(t *testing.T) {
 			},
 		},
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/notifier.go
+++ b/notifier.go
@@ -20,15 +20,13 @@ import (
 type Notifier struct {
 	cfg *Configuration
 
-	// sessions
-	sessionCh              chan *session
 	sessions               []*session
 	sessionPublishInterval time.Duration
 
-	loopOnce sync.Once
-
 	reportCh   chan *report
+	sessionCh  chan *session
 	shutdownCh chan struct{}
+	loopOnce   sync.Once
 }
 
 type report struct {

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -98,3 +98,13 @@ func TestMakeExceptions(t *testing.T) {
 		}
 	]`)
 }
+
+func TestShuttingDown(t *testing.T) {
+	n, err := New(Configuration{APIKey: "abcd1234abcd1234abcd1234abcd1234", ReleaseStage: "dev", AppVersion: "1.2.3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := n.StartSession(context.Background())
+	n.Notify(ctx, fmt.Errorf("oooi"))
+	n.Close()
+}

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -110,7 +110,7 @@ func TestShuttingDown(t *testing.T) {
 		n.Close()
 	})
 
-	t.Run("doens't panic even if StartSession and Notify are uncalled", func(t *testing.T) {
+	t.Run("doesn't panic even if StartSession and Notify are uncalled", func(t *testing.T) {
 		n, err := New(Configuration{APIKey: "abcd1234abcd1234abcd1234abcd1234", ReleaseStage: "dev", AppVersion: "1.2.3"})
 		if err != nil {
 			t.Fatal(err)

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -100,11 +100,21 @@ func TestMakeExceptions(t *testing.T) {
 }
 
 func TestShuttingDown(t *testing.T) {
-	n, err := New(Configuration{APIKey: "abcd1234abcd1234abcd1234abcd1234", ReleaseStage: "dev", AppVersion: "1.2.3"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	ctx := n.StartSession(context.Background())
-	n.Notify(ctx, fmt.Errorf("oooi"))
-	n.Close()
+	t.Run("doesn't panic if invoking StartSession or Notify", func(t *testing.T) {
+		n, err := New(Configuration{APIKey: "abcd1234abcd1234abcd1234abcd1234", ReleaseStage: "dev", AppVersion: "1.2.3"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx := n.StartSession(context.Background())
+		n.Notify(ctx, fmt.Errorf("oooi"))
+		n.Close()
+	})
+
+	t.Run("doens't panic even if StartSession and Notify are uncalled", func(t *testing.T) {
+		n, err := New(Configuration{APIKey: "abcd1234abcd1234abcd1234abcd1234", ReleaseStage: "dev", AppVersion: "1.2.3"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		n.Close()
+	})
 }

--- a/session_test.go
+++ b/session_test.go
@@ -54,10 +54,9 @@ func TestSessions(t *testing.T) {
 				notifierVersion: "0.1.0",
 			},
 		},
-		sessionChannel:         make(chan *session, 1),
+		sessionCh:              make(chan *session, 1),
 		sessionPublishInterval: time.Microsecond, // Just to make things go a bit faster,
 	}
-	go n.startSessionTracking()
 	n.StartSession(context.Background())
 
 	jsonassert.New(t).Assertf(<-payloads, `{


### PR DESCRIPTION
This method flushes the unsent reports and sessions upon being invoked.
Note: This method does not conform to the io.Closer interface because it
doesn't return an error.
I'm not a fan of this function returning an error in the first place, so
instead of propagating unnecessary
  defer func(){_ = n.Close()}()
where the Close func never returns an error anyway just to adhere to the
interface, I decided to not return anything in the first place.

Additional changes:
- Conform to a stricter "gofumports" formatting ruleset
- Define a larger size for the buffered channels since both sessions and
  error reports share the same select statement.
- Stop flushing sessions in new goroutines, and get rid of the mutexes.