### PR TITLE
[feat] Add Fallback Configuration field

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -42,6 +42,12 @@ type Configuration struct {
 	// to Bugsnag.
 	SessionReportSanitizer SessionReportSanitizer
 
+	// Fallback gets invoked with a descriptive error for any internal issues
+	// in the notifier that's preventing normal operation.
+	// Configuring this function may be useful if you need to debug missing
+	// reports or sessions.
+	Fallback func(err error)
+
 	runtimeConstants
 }
 

--- a/session.go
+++ b/session.go
@@ -47,12 +47,12 @@ func (n *Notifier) flushSessions() {
 	}
 
 	if err := n.publishSessions(n.cfg, sessions); err != nil {
-		logErr(err)
+		n.cfg.Fallback(fmt.Errorf("unable to publish sessions: %w", err))
 	}
 }
 
 func (n *Notifier) publishSessions(cfg *Configuration, sessions []*session) error {
-	report := makeJSONSessionReport(cfg, sessions)
+	report := n.makeJSONSessionReport(cfg, sessions)
 	ctx := context.Background()
 	if sanitizer := n.cfg.SessionReportSanitizer; sanitizer != nil {
 		ctx = sanitizer(report)
@@ -116,11 +116,11 @@ func makeJSONSession(ctx context.Context, unhandled bool) *JSONSession {
 	return nil
 }
 
-func makeJSONSessionReport(cfg *Configuration, sessions []*session) *JSONSessionReport {
+func (n *Notifier) makeJSONSessionReport(cfg *Configuration, sessions []*session) *JSONSessionReport {
 	return &JSONSessionReport{
 		Notifier: makeNotifier(cfg),
 		App:      makeJSONApp(cfg),
-		Device:   cfg.makeJSONDevice(),
+		Device:   n.makeJSONDevice(),
 		SessionCounts: []JSONSessionCounts{
 			{
 				// This timestamp assumes that the sessions happen at more or


### PR DESCRIPTION
This can be used to monitor issues internal to the notifier that would
otherwise lead to awkward API interfaces.