### PR TITLE
[fix] Prevent the notifier from ever panicking

### DIFF
--- a/notifier_test.go
+++ b/notifier_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -102,9 +103,21 @@ func TestMakeExceptions(t *testing.T) {
 	]`)
 }
 
-func TestShuttingDown(t *testing.T) {
+func TestNoPanicsWhenShuttingDown(t *testing.T) {
+	cfg := Configuration{
+		APIKey:       "abcd1234abcd1234abcd1234abcd1234",
+		ReleaseStage: "dev",
+		AppVersion:   "1.2.3",
+		// Dummy endpoints to avoid accidentally sending payloads to Bugsnag.
+		// Note that the panics are most likely to occur *after* any execution
+		// of the Sanitizer functions, and thus setting different endpoints
+		// that will fail are more appropriate.
+		EndpointNotify:   "http://0.0.0.0:1234",
+		EndpointSessions: "http://0.0.0.0:1234",
+	}
+
 	t.Run("doesn't panic if invoking StartSession or Notify", func(t *testing.T) {
-		n, err := New(Configuration{APIKey: "abcd1234abcd1234abcd1234abcd1234", ReleaseStage: "dev", AppVersion: "1.2.3"})
+		n, err := New(cfg)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -113,12 +126,72 @@ func TestShuttingDown(t *testing.T) {
 		n.Close()
 	})
 
-	t.Run("doesn't panic even if StartSession and Notify are uncalled", func(t *testing.T) {
-		n, err := New(Configuration{APIKey: "abcd1234abcd1234abcd1234abcd1234", ReleaseStage: "dev", AppVersion: "1.2.3"})
+	t.Run("StartSession and Notify are uncalled", func(t *testing.T) {
+		n, err := New(cfg)
 		if err != nil {
 			t.Fatal(err)
 		}
 		n.Close()
+	})
+
+	t.Run("Notify after Close invokes InternalErrorCallback", func(t *testing.T) {
+		var got error
+		cfg.InternalErrorCallback = func(err error) { got = err }
+
+		n, err := New(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		n.Close()
+		n.Notify(context.Background(), fmt.Errorf("oops"))
+
+		if got == nil {
+			t.Fatal("expected error but got none")
+		}
+
+		if exp, got := "did you invoke Notify", got.Error(); !strings.Contains(got, exp) {
+			t.Errorf("expected error message containing %s but got %s", exp, got)
+		}
+	})
+
+	t.Run("StartSession after Close invokes InternalErrorCallback", func(t *testing.T) {
+		var got error
+		cfg.InternalErrorCallback = func(err error) { got = err }
+
+		n, err := New(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		n.Close()
+		n.StartSession(context.Background())
+
+		if got == nil {
+			t.Fatal("expected error but got none")
+		}
+
+		if exp, got := "did you invoke StartSession", got.Error(); !strings.Contains(got, exp) {
+			t.Errorf("expected error message containing %s but got %s", exp, got)
+		}
+	})
+
+	t.Run("Close after Close invokes InternalErrorCallback", func(t *testing.T) {
+		var got error
+		cfg.InternalErrorCallback = func(err error) { got = err }
+
+		n, err := New(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		n.Close()
+		n.Close()
+
+		if got == nil {
+			t.Fatal("expected error but got none")
+		}
+
+		if exp, got := "did you invoke Close", got.Error(); !strings.Contains(got, exp) {
+			t.Errorf("expected error message containing %s but got %s", exp, got)
+		}
 	})
 }
 

--- a/session.go
+++ b/session.go
@@ -29,6 +29,10 @@ type SessionReportSanitizer func(p *JSONSessionReport) context.Context
 // context.Context, and returns the new context.Context.
 // Records the newly started session and will at some point flush this session.
 func (n *Notifier) StartSession(ctx context.Context) context.Context {
+	// Ideally we wouldn't need this guard, but it's the best way I can see to
+	// prevent this package from ever panicking.
+	defer n.guard("StartSession")
+
 	n.loopOnce.Do(func() { go n.loop() })
 	session := &session{
 		StartedAt:   time.Now(),


### PR DESCRIPTION
Recovers if methods that might call a closed channel panics:

- StartSession
- Notify
- Close

Also proves that InternalErrorCallback gets invoked on internal notifier
errors.