### PR TITLE
Api on notifier

### DIFF
--- a/context.go
+++ b/context.go
@@ -174,7 +174,11 @@ type User struct {
 // WithUser attaches the given User data to the given context, such that it can
 // later be provided to the Notify method, and have this data show up in your
 // dashboard.
-func WithUser(ctx context.Context, user User) context.Context {
+func (n *Notifier) WithUser(ctx context.Context, user User) context.Context {
+	// This function currently uses no features of the Notifier type, however
+	// we're attaching it to the Notifier to ensure that we can use
+	// Notifier-only functionalities in the future AND so that users need only
+	// import the bugsnag package in a single location in their app.
 	cd := getAttachedContextData(ctx)
 	cd.User = &user
 	return context.WithValue(ctx, ctxDataKey, cd)

--- a/context.go
+++ b/context.go
@@ -187,7 +187,11 @@ func (n *Notifier) WithUser(ctx context.Context, user User) context.Context {
 // WithBugsnagContext applies the given bContext as the "Context" for the errors that
 // show up in your Bugsnag dashboard. The naming here is unfortunate, but to be
 // fair, Bugsnag had this nomenclature before Go did...
-func WithBugsnagContext(ctx context.Context, bContext string) context.Context {
+func (n *Notifier) WithBugsnagContext(ctx context.Context, bContext string) context.Context {
+	// This function currently uses no features of the Notifier type, however
+	// we're attaching it to the Notifier to ensure that we can use
+	// Notifier-only functionalities in the future AND so that users need only
+	// import the bugsnag package in a single location in their app.
 	cd := getAttachedContextData(ctx)
 	cd.BContext = bContext
 	return context.WithValue(ctx, ctxDataKey, cd)

--- a/context.go
+++ b/context.go
@@ -124,7 +124,11 @@ type Breadcrumb struct {
 
 // WithBreadcrumb attaches a breadcrumb to the top of the stack of breadcrumbs
 // stored in the given context.
-func WithBreadcrumb(ctx context.Context, b Breadcrumb) context.Context {
+func (n *Notifier) WithBreadcrumb(ctx context.Context, b Breadcrumb) context.Context {
+	// This function currently uses no features of the Notifier type, however
+	// we're attaching it to the Notifier to ensure that we can use
+	// Notifier-only functionalities in the future AND so that users need only
+	// import the bugsnag package in a single location in their app.
 	if b.Timestamp.IsZero() {
 		b.Timestamp = time.Now().UTC()
 	}

--- a/context.go
+++ b/context.go
@@ -201,17 +201,21 @@ func (n *Notifier) WithBugsnagContext(ctx context.Context, bContext string) cont
 // Bugsnag dashboard. You may use the following tab names to add data to
 // existing/common tabs in the dashboard with the same name:
 //   "user", "app", "device", "request"
-func WithMetadatum(ctx context.Context, tab, key string, value interface{}) context.Context {
+func (n *Notifier) WithMetadatum(ctx context.Context, tab, key string, value interface{}) context.Context {
 	m := initializeMetadataTab(ctx, tab)
 	m[tab][key] = value
-	return WithMetadata(ctx, tab, m[tab])
+	return n.WithMetadata(ctx, tab, m[tab])
 }
 
 // WithMetadata attaches the given data under the provided tab in the
 // Bugsnag dashboard. You may use the following tab names to add data to
 // existing/common tabs in the dashboard with the same name:
 //   "user", "app", "device", "request"
-func WithMetadata(ctx context.Context, tab string, data map[string]interface{}) context.Context {
+func (n *Notifier) WithMetadata(ctx context.Context, tab string, data map[string]interface{}) context.Context {
+	// This function currently uses no features of the Notifier type, however
+	// we're attaching it to the Notifier to ensure that we can use
+	// Notifier-only functionalities in the future AND so that users need only
+	// import the bugsnag package in a single location in their app.
 	m := initializeMetadataTab(ctx, tab)
 	m[tab] = data
 	cd := getAttachedContextData(ctx)

--- a/context.go
+++ b/context.go
@@ -225,12 +225,16 @@ func (n *Notifier) WithMetadata(ctx context.Context, tab string, data map[string
 
 // Metadata pulls out all the metadata known by this package as a
 // map[tab]map[key]value from the given context.
-func Metadata(ctx context.Context) map[string]map[string]interface{} {
+func (n *Notifier) Metadata(ctx context.Context) map[string]map[string]interface{} {
+	// This function currently uses no features of the Notifier type, however
+	// we're attaching it to the Notifier to ensure that we can use
+	// Notifier-only functionalities in the future AND so that users need only
+	// import the bugsnag package in a single location in their app.
 	return getAttachedContextData(ctx).Metadata
 }
 
 func initializeMetadataTab(ctx context.Context, tab string) map[string]map[string]interface{} {
-	m := Metadata(ctx)
+	m := getAttachedContextData(ctx).Metadata
 	if m == nil {
 		m = map[string]map[string]interface{}{}
 	}
@@ -255,7 +259,7 @@ func extractAugmentedContextData(ctx context.Context, err error, unhandled bool)
 		breadcrumbs: makeBreadcrumbs(ctx),
 		user:        getAttachedContextData(ctx).User,
 		session:     makeJSONSession(ctx, unhandled),
-		metadata:    Metadata(ctx),
+		metadata:    getAttachedContextData(ctx).Metadata,
 	}
 	lowestCtx := ctx
 	var e error = err
@@ -293,7 +297,7 @@ func (data *jsonCtxData) updateFromCtx(ctx context.Context, unhandled bool) {
 		data.session = dataSession
 	}
 
-	dataMetadata := Metadata(ctx)
+	dataMetadata := getAttachedContextData(ctx).Metadata
 	if dataMetadata == nil {
 		return
 	}

--- a/context_test.go
+++ b/context_test.go
@@ -8,54 +8,55 @@ import (
 	"github.com/kinbiko/jsonassert"
 )
 
-func TestBreadcrumbs(t *testing.T) {
+func TestContextWithMethods(t *testing.T) {
 	n, err := New(Configuration{APIKey: "1234abcd1234abcd1234abcd1234abcd", AppVersion: "1.2.3", ReleaseStage: "test"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	asJSON := func(s interface{}) string {
-		b, err := json.Marshal(s)
-		if err != nil {
-			return "<<ERROR>>"
+	t.Run("WithBreadcrumb", func(t *testing.T) {
+		asJSON := func(s interface{}) string {
+			b, err := json.Marshal(s)
+			if err != nil {
+				return "<<ERROR>>"
+			}
+			return string(b)
 		}
-		return string(b)
-	}
 
-	expLatest := Breadcrumb{Name: "latest"}
-	expNewest := Breadcrumb{Name: "newest", Type: BCTypeLog, Metadata: map[string]interface{}{"md": 1}}
+		expLatest := Breadcrumb{Name: "latest"}
+		expNewest := Breadcrumb{Name: "newest", Type: BCTypeLog, Metadata: map[string]interface{}{"md": 1}}
 
-	ctx := context.Background()
-	ctx = n.WithBreadcrumb(ctx, expLatest)
-	ctx = n.WithBreadcrumb(ctx, expNewest)
+		ctx := n.WithBreadcrumb(context.Background(), expLatest)
+		ctx = n.WithBreadcrumb(ctx, expNewest)
 
-	bcs := makeBreadcrumbs(ctx)
+		bcs := makeBreadcrumbs(ctx)
 
-	if len(bcs) != 2 {
-		t.Fatalf("expected 2 breadcrumbs but got %d", len(bcs))
-	}
+		if len(bcs) != 2 {
+			t.Fatalf("expected 2 breadcrumbs but got %d", len(bcs))
+		}
 
-	ja := jsonassert.New(t)
-	ja.Assertf(asJSON(bcs[0]), `{ "timestamp": "<<PRESENCE>>", "name": "newest", "type": "log", "metaData": { "md": 1 } }`)
-	ja.Assertf(asJSON(bcs[1]), `{ "timestamp": "<<PRESENCE>>", "name": "latest", "type": "manual" }`)
-}
+		ja := jsonassert.New(t)
+		ja.Assertf(asJSON(bcs[0]), `{ "timestamp": "<<PRESENCE>>", "name": "newest", "type": "log", "metaData": { "md": 1 } }`)
+		ja.Assertf(asJSON(bcs[1]), `{ "timestamp": "<<PRESENCE>>", "name": "latest", "type": "manual" }`)
+	})
 
-func TestUserAndContext(t *testing.T) {
-	exp := User{ID: "id", Name: "name", Email: "email"}
-	if got := getAttachedContextData(WithUser(context.Background(), exp)).User; *got != exp {
-		t.Errorf("expected that when I add '%+v' to the context what I get back ('%+v') should be equal", exp, got)
-	}
-}
+	t.Run("WithUser", func(t *testing.T) {
+		exp := User{ID: "id", Name: "name", Email: "email"}
+		if got := getAttachedContextData(WithUser(context.Background(), exp)).User; *got != exp {
+			t.Errorf("expected that when I add '%+v' to the context what I get back ('%+v') should be equal", exp, got)
+		}
+	})
 
-func TestMetadata(t *testing.T) {
-	ctx := WithMetadatum(context.Background(), "app", "id", "15011-2")
-	ctx = WithMetadata(ctx, "device", map[string]interface{}{"model": "15023-2"})
-	md := Metadata(ctx)
-	if appID, exp := md["app"]["id"], "15011-2"; appID != exp {
-		t.Errorf("expected app.id to be '%s' but was '%s'", exp, appID)
-	}
-	if deviceModel, exp := md["device"]["model"], "15023-2"; deviceModel != exp {
-		t.Errorf("expected device.model to be '%s' but was '%s'", exp, deviceModel)
-	}
+	t.Run("WithMetadata and WithMetadatum", func(t *testing.T) {
+		ctx := WithMetadatum(context.Background(), "app", "id", "15011-2")
+		ctx = WithMetadata(ctx, "device", map[string]interface{}{"model": "15023-2"})
+		md := Metadata(ctx)
+		if appID, exp := md["app"]["id"], "15011-2"; appID != exp {
+			t.Errorf("expected app.id to be '%s' but was '%s'", exp, appID)
+		}
+		if deviceModel, exp := md["device"]["model"], "15023-2"; deviceModel != exp {
+			t.Errorf("expected device.model to be '%s' but was '%s'", exp, deviceModel)
+		}
+	})
 }
 
 func TestCtxSerialization(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -49,7 +49,7 @@ func TestContextWithMethods(t *testing.T) {
 	t.Run("WithMetadata and WithMetadatum", func(t *testing.T) {
 		ctx := n.WithMetadatum(context.Background(), "app", "id", "15011-2")
 		ctx = n.WithMetadata(ctx, "device", map[string]interface{}{"model": "15023-2"})
-		md := Metadata(ctx)
+		md := n.Metadata(ctx)
 		if appID, exp := md["app"]["id"], "15011-2"; appID != exp {
 			t.Errorf("expected app.id to be '%s' but was '%s'", exp, appID)
 		}

--- a/context_test.go
+++ b/context_test.go
@@ -47,8 +47,8 @@ func TestContextWithMethods(t *testing.T) {
 	})
 
 	t.Run("WithMetadata and WithMetadatum", func(t *testing.T) {
-		ctx := WithMetadatum(context.Background(), "app", "id", "15011-2")
-		ctx = WithMetadata(ctx, "device", map[string]interface{}{"model": "15023-2"})
+		ctx := n.WithMetadatum(context.Background(), "app", "id", "15011-2")
+		ctx = n.WithMetadata(ctx, "device", map[string]interface{}{"model": "15023-2"})
 		md := Metadata(ctx)
 		if appID, exp := md["app"]["id"], "15011-2"; appID != exp {
 			t.Errorf("expected app.id to be '%s' but was '%s'", exp, appID)
@@ -64,8 +64,8 @@ func TestCtxSerialization(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = n.WithBreadcrumb(ctx, Breadcrumb{Name: "log event", Type: BCTypeLog, Metadata: map[string]interface{}{"msg": "ruh roh"}})
-	ctx = WithMetadata(ctx, "app", map[string]interface{}{"nick": "charmander"})
-	ctx = WithMetadatum(ctx, "app", "types", []string{"fire"})
+	ctx = n.WithMetadata(ctx, "app", map[string]interface{}{"nick": "charmander"})
+	ctx = n.WithMetadatum(ctx, "app", "types", []string{"fire"})
 	ctx = n.WithUser(ctx, User{ID: "qwpeoiub", Name: "charlie", Email: "charlie@pokemon.example.com"})
 	ctx = n.WithBugsnagContext(ctx, "/pokemon?type=fire")
 

--- a/context_test.go
+++ b/context_test.go
@@ -41,7 +41,7 @@ func TestContextWithMethods(t *testing.T) {
 
 	t.Run("WithUser", func(t *testing.T) {
 		exp := User{ID: "id", Name: "name", Email: "email"}
-		if got := getAttachedContextData(WithUser(context.Background(), exp)).User; *got != exp {
+		if got := getAttachedContextData(n.WithUser(context.Background(), exp)).User; *got != exp {
 			t.Errorf("expected that when I add '%+v' to the context what I get back ('%+v') should be equal", exp, got)
 		}
 	})
@@ -66,7 +66,7 @@ func TestCtxSerialization(t *testing.T) {
 	ctx = n.WithBreadcrumb(ctx, Breadcrumb{Name: "log event", Type: BCTypeLog, Metadata: map[string]interface{}{"msg": "ruh roh"}})
 	ctx = WithMetadata(ctx, "app", map[string]interface{}{"nick": "charmander"})
 	ctx = WithMetadatum(ctx, "app", "types", []string{"fire"})
-	ctx = WithUser(ctx, User{ID: "qwpeoiub", Name: "charlie", Email: "charlie@pokemon.example.com"})
+	ctx = n.WithUser(ctx, User{ID: "qwpeoiub", Name: "charlie", Email: "charlie@pokemon.example.com"})
 	ctx = WithBugsnagContext(ctx, "/pokemon?type=fire")
 
 	t.Run("json serialization", func(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -67,7 +67,7 @@ func TestCtxSerialization(t *testing.T) {
 	ctx = WithMetadata(ctx, "app", map[string]interface{}{"nick": "charmander"})
 	ctx = WithMetadatum(ctx, "app", "types", []string{"fire"})
 	ctx = n.WithUser(ctx, User{ID: "qwpeoiub", Name: "charlie", Email: "charlie@pokemon.example.com"})
-	ctx = WithBugsnagContext(ctx, "/pokemon?type=fire")
+	ctx = n.WithBugsnagContext(ctx, "/pokemon?type=fire")
 
 	t.Run("json serialization", func(t *testing.T) {
 		b, _ := json.Marshal(getAttachedContextData(ctx))

--- a/context_test.go
+++ b/context_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestBreadcrumbs(t *testing.T) {
+	n, err := New(Configuration{APIKey: "1234abcd1234abcd1234abcd1234abcd", AppVersion: "1.2.3", ReleaseStage: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
 	asJSON := func(s interface{}) string {
 		b, err := json.Marshal(s)
 		if err != nil {
@@ -21,8 +25,8 @@ func TestBreadcrumbs(t *testing.T) {
 	expNewest := Breadcrumb{Name: "newest", Type: BCTypeLog, Metadata: map[string]interface{}{"md": 1}}
 
 	ctx := context.Background()
-	ctx = WithBreadcrumb(ctx, expLatest)
-	ctx = WithBreadcrumb(ctx, expNewest)
+	ctx = n.WithBreadcrumb(ctx, expLatest)
+	ctx = n.WithBreadcrumb(ctx, expNewest)
 
 	bcs := makeBreadcrumbs(ctx)
 
@@ -58,7 +62,7 @@ func TestCtxSerialization(t *testing.T) {
 	n, err := New(Configuration{APIKey: "1234abcd1234abcd1234abcd1234abcd", AppVersion: "1.2.3", ReleaseStage: "test"})
 
 	ctx := context.Background()
-	ctx = WithBreadcrumb(ctx, Breadcrumb{Name: "log event", Type: BCTypeLog, Metadata: map[string]interface{}{"msg": "ruh roh"}})
+	ctx = n.WithBreadcrumb(ctx, Breadcrumb{Name: "log event", Type: BCTypeLog, Metadata: map[string]interface{}{"msg": "ruh roh"}})
 	ctx = WithMetadata(ctx, "app", map[string]interface{}{"nick": "charmander"})
 	ctx = WithMetadatum(ctx, "app", "types", []string{"fire"})
 	ctx = WithUser(ctx, User{ID: "qwpeoiub", Name: "charlie", Email: "charlie@pokemon.example.com"})

--- a/context_test.go
+++ b/context_test.go
@@ -55,6 +55,8 @@ func TestMetadata(t *testing.T) {
 }
 
 func TestCtxSerialization(t *testing.T) {
+	n, err := New(Configuration{APIKey: "1234abcd1234abcd1234abcd1234abcd", AppVersion: "1.2.3", ReleaseStage: "test"})
+
 	ctx := context.Background()
 	ctx = WithBreadcrumb(ctx, Breadcrumb{Name: "log event", Type: BCTypeLog, Metadata: map[string]interface{}{"msg": "ruh roh"}})
 	ctx = WithMetadata(ctx, "app", map[string]interface{}{"nick": "charmander"})
@@ -73,7 +75,10 @@ func TestCtxSerialization(t *testing.T) {
 	})
 
 	t.Run("serialize + deserialize yields the same data", func(t *testing.T) {
-		ctx = Deserialize(context.Background(), Serialize(ctx))
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx = n.Deserialize(context.Background(), n.Serialize(ctx))
 		b, _ := json.Marshal(getAttachedContextData(ctx))
 		jsonassert.New(t).Assertf(string(b), `{
 			"cx": "/pokemon?type=fire",

--- a/integration_test.go
+++ b/integration_test.go
@@ -61,8 +61,8 @@ func TestIntegration(t *testing.T) {
 
 	ctx = ntf.WithBugsnagContext(ctx, "User batch job")
 
-	ctx = bugsnag.WithMetadata(ctx, "myTab", map[string]interface{}{"hello": 423})
-	ctx = bugsnag.WithMetadatum(ctx, "myTab", "goodbye", "cruel world")
+	ctx = ntf.WithMetadata(ctx, "myTab", map[string]interface{}{"hello": 423})
+	ctx = ntf.WithMetadatum(ctx, "myTab", "goodbye", "cruel world")
 
 	err := ntf.Wrap(context.Background(), errors.New("oh ploppers"))
 	err.Unhandled = true

--- a/integration_test.go
+++ b/integration_test.go
@@ -59,7 +59,7 @@ func TestIntegration(t *testing.T) {
 		Metadata: map[string]interface{}{"md": "bar"},
 	})
 
-	ctx = bugsnag.WithBugsnagContext(ctx, "User batch job")
+	ctx = ntf.WithBugsnagContext(ctx, "User batch job")
 
 	ctx = bugsnag.WithMetadata(ctx, "myTab", map[string]interface{}{"hello": 423})
 	ctx = bugsnag.WithMetadatum(ctx, "myTab", "goodbye", "cruel world")

--- a/integration_test.go
+++ b/integration_test.go
@@ -47,13 +47,13 @@ func TestIntegration(t *testing.T) {
 	})
 	ctx = ntf.StartSession(ctx)
 
-	ctx = bugsnag.WithBreadcrumb(ctx, bugsnag.Breadcrumb{
+	ctx = ntf.WithBreadcrumb(ctx, bugsnag.Breadcrumb{
 		Name:     "something happened",
 		Type:     bugsnag.BCTypeProcess,
 		Metadata: map[string]interface{}{"md": "foo"},
 	})
 
-	ctx = bugsnag.WithBreadcrumb(ctx, bugsnag.Breadcrumb{
+	ctx = ntf.WithBreadcrumb(ctx, bugsnag.Breadcrumb{
 		Name:     "something else happened",
 		Type:     bugsnag.BCTypeRequest,
 		Metadata: map[string]interface{}{"md": "bar"},

--- a/integration_test.go
+++ b/integration_test.go
@@ -40,7 +40,7 @@ func TestIntegration(t *testing.T) {
 		ReleaseStage:     "staging",
 	})
 
-	ctx := bugsnag.WithUser(context.Background(), bugsnag.User{
+	ctx := ntf.WithUser(context.Background(), bugsnag.User{
 		ID:    "1234",
 		Name:  "River Tam",
 		Email: "river@serenity.space",

--- a/notifier.go
+++ b/notifier.go
@@ -390,7 +390,7 @@ func extractLowestBugsnagError(err error) *Error {
 }
 
 func (n *Notifier) guard(method string) {
-	if p := recover(); p != nil && n.cfg.InternalErrorCallback != nil {
+	if p := recover(); p != nil {
 		n.cfg.InternalErrorCallback(fmt.Errorf("panic when calling %s (did you invoke %s after calling Close?): %v", method, method, p))
 	}
 }

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -68,11 +68,11 @@ func TestMakeExceptions(t *testing.T) {
 	}
 
 	ctx := n.WithBugsnagContext(context.Background(), "/api/user/1523")
-	ctx = WithMetadatum(ctx, "tab", "one", "1")
+	ctx = n.WithMetadatum(ctx, "tab", "one", "1")
 
 	err = errors.New("1st error (errors.New)")
 	err = fmt.Errorf("2nd error (github.com/pkg/errors.Wrap): %w", err)
-	err = n.Wrap(WithMetadatum(ctx, "tab", "two", "2"), err, "3rd error (%s.(*Notifier).Wrap)", "bugsnag")
+	err = n.Wrap(n.WithMetadatum(ctx, "tab", "two", "2"), err, "3rd error (%s.(*Notifier).Wrap)", "bugsnag")
 	err = fmt.Errorf("4th error (fmt.Errorf('percent-w')): %w", err)
 
 	eps := makeExceptions(err)

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -67,7 +67,7 @@ func TestMakeExceptions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := WithBugsnagContext(context.Background(), "/api/user/1523")
+	ctx := n.WithBugsnagContext(context.Background(), "/api/user/1523")
 	ctx = WithMetadatum(ctx, "tab", "one", "1")
 
 	err = errors.New("1st error (errors.New)")


### PR DESCRIPTION
Pulls out the `With*` methods, and a couple of others to the `Notifier` type.

### Advantages to this approach

- Prevents import pollution of this package. The user can import the `github.com/kinbiko/bugsnag` package in one file, and pass it to other types via dependency injection + interfaces.
- More future proof, as new features in the Notifier type are now available on most of the API. E.g. Deserialize can now call the `InternalErrorCallback` which is user-injected, and only available on the `*Notifier`.

### Disadvantages to this approach

- Tempts the user into creating a global Notifier (in their package), so that they can access these methods which really don't need to be methods, instead of directly accessing the methods from the bugsnag package.

Notably *not* included in this, is deleting the package-level Wrap function.
The reasoning here is that in a service-organised application, context information would most likely be attached at the method (≠function) level, before calling into other service methods, propagating the context. Errors on the other hand may occur at any level, and being able to call Wrap in a package level ('static') function without forcing the users to pass the notifier around everywhere is worth it in order to get the lowest possible stackframes. Context data, on the other hand, are most likely identical higher up the stack, and the error can be notified/re-wrapped at this point.