### PR TITLE
[feat] Add sourcepath heuristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ if err != nil {
 defer notifier.Close() // Close once you know there are no further calls to notifier.Notify or notifier.StartSession.
 ```
 
+In order to get the most accurate filepaths in stacktraces (generated in the case of panics and `bugsnag.Error`s), make sure to build (or run) your application with the `-trimpath` flag set:
+
+```
+go build -trimpath ./cmd/myapp
+```
+
+Applications built without `-trimpath` have stacktraces that appear with absolute paths of the machine where `go build` was executed.
+
 ### Reporting errors
 
 The Notifier is now ready for use.

--- a/error.go
+++ b/error.go
@@ -141,9 +141,10 @@ func calculateSourcepathHeuristic(file string) string {
 		//   "bugsnag",
 		//   "examples/cmd/cli/main.go",
 		// ]
-		split := strings.SplitN(file, "/", 4)
-		if len(split) == 4 {
-			return split[3]
+		numSplits := 4
+		split := strings.SplitN(file, "/", numSplits)
+		if len(split) == numSplits {
+			return split[numSplits-1]
 		}
 	}
 	return file


### PR DESCRIPTION
For in-project files hosted on GitHub, try to infer the "correct" path to the file so that the Bugsnag dashboard's links to source control per frame works assuming the following:

> The file is hosted relative to the third '/' character of the full path of the file.

E.g. 
```
github.com/kinbiko/bugsnag/examples/cmd/cli/main.go
```
Gets trimmed down to
```
examples/cmd/cli/main.go
```

Non-GitHub or non-in-project files are ignored and their full paths are still shown.

Closes #27 

## Checklist

- [x] I have done a self-review of the PR.
